### PR TITLE
Move swagger to separate package to avoid bloating downstream dependants

### DIFF
--- a/provider/docs/generate.go
+++ b/provider/docs/generate.go
@@ -1,4 +1,4 @@
 package docs
 
 // Run using "go generate ./..."
-//go:generate go run github.com/swaggo/swag/cmd/swag@latest init -g ./ops/swagger.go -d ../../ -o ./generated/ --instanceName provider --ot go,yaml
+//go:generate go run github.com/swaggo/swag/cmd/swag@latest init -g ./swagger/swagger.go -d ../../ -o ./generated/ --instanceName provider --ot go,yaml

--- a/server/server.go
+++ b/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/valkyrie-fnd/valkyrie/ops"
 	"github.com/valkyrie-fnd/valkyrie/pam"
 	"github.com/valkyrie-fnd/valkyrie/routes"
+	"github.com/valkyrie-fnd/valkyrie/swagger"
 
 	_ "github.com/valkyrie-fnd/valkyrie/pam/genericpam" // init generic pam
 	_ "github.com/valkyrie-fnd/valkyrie/pam/vplugin"    // init pam plugins
@@ -90,7 +91,7 @@ func NewValkyrie(ctx context.Context, cfg *configs.ValkyrieConfig) *Valkyrie {
 	}
 
 	// Swagger
-	err = ops.ConfigureSwagger(v.config, v.provider, v.operator)
+	err = swagger.ConfigureSwagger(v.config, v.provider, v.operator)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to configure swagger")
 	}

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -1,4 +1,4 @@
-package ops
+package swagger
 
 import (
 	"strings"

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -1,3 +1,4 @@
+// Package swagger adds API documentation endpoints
 package swagger
 
 import (

--- a/swagger/swagger_test.go
+++ b/swagger/swagger_test.go
@@ -1,4 +1,4 @@
-package ops
+package swagger
 
 import (
 	"testing"


### PR DESCRIPTION
Plugins having a Valkyrie/rest dependency can avoid the big Swagger transitive dependency if it is in a separate package