### PR TITLE
Split request/response logging into separate log statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Split request/response logging into separate log statements
+
 ### Removed
 
 

--- a/ops/logging_middleware.go
+++ b/ops/logging_middleware.go
@@ -40,6 +40,8 @@ var pathPing = []byte("/ping")
 
 // Adds request and response to log
 func requestResponseLogging(c *fiber.Ctx) error {
+	log.Ctx(c.UserContext()).Debug().Func(LogHTTPRequest(c.Request())).Msg("http server request")
+
 	err := c.Next()
 
 	// Ignore ping
@@ -47,7 +49,11 @@ func requestResponseLogging(c *fiber.Ctx) error {
 		return nil
 	}
 
-	log.Ctx(c.UserContext()).Debug().Func(LogHTTPEvent(c.Request(), c.Response(), err)).Msg("http incoming")
+	if err != nil {
+		log.Ctx(c.UserContext()).Error().Func(LogHTTPResponse(c.Response(), err)).Msg("http server response")
+	} else {
+		log.Ctx(c.UserContext()).Debug().Func(LogHTTPResponse(c.Response(), nil)).Msg("http server response")
+	}
 
 	return err
 }

--- a/rest/client.go
+++ b/rest/client.go
@@ -229,12 +229,13 @@ func (c Client) postOrPut(
 	resp := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseResponse(resp)
 
-	err := c.fastClient.DoTimeout(req, resp, c.config.RequestTimeout)
+	log.Ctx(ctx).Debug().Func(ops.LogHTTPRequest(req)).Msg("http client request")
 
+	err := c.fastClient.DoTimeout(req, resp, c.config.RequestTimeout)
 	if err != nil {
-		log.Ctx(ctx).Error().Func(ops.LogHTTPEvent(req, resp, err)).Msg("http outgoing")
+		log.Ctx(ctx).Error().Func(ops.LogHTTPResponse(resp, err)).Msg("http client response")
 	} else {
-		log.Ctx(ctx).Debug().Func(ops.LogHTTPEvent(req, resp, err)).Msg("http outgoing")
+		log.Ctx(ctx).Debug().Func(ops.LogHTTPResponse(resp, err)).Msg("http client response")
 	}
 	ops.TraceHTTPAttributes(span, req, resp, err)
 
@@ -285,12 +286,13 @@ func (c Client) get(
 	resp := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseResponse(resp)
 
-	err := c.fastClient.DoTimeout(req, resp, c.config.RequestTimeout)
+	log.Ctx(ctx).Debug().Func(ops.LogHTTPRequest(req)).Msg("http client request")
 
+	err := c.fastClient.DoTimeout(req, resp, c.config.RequestTimeout)
 	if err != nil {
-		log.Ctx(ctx).Error().Func(ops.LogHTTPEvent(req, resp, err)).Msg("http outgoing")
+		log.Ctx(ctx).Error().Func(ops.LogHTTPResponse(resp, err)).Msg("http client response")
 	} else {
-		log.Ctx(ctx).Debug().Func(ops.LogHTTPEvent(req, resp, err)).Msg("http outgoing")
+		log.Ctx(ctx).Debug().Func(ops.LogHTTPResponse(resp, err)).Msg("http client response")
 	}
 	ops.TraceHTTPAttributes(span, req, resp, err)
 


### PR DESCRIPTION
Also adjusted logging message slightly to `http server/http client` since I found that to be a bit more clear.

Next would be to update oss-vplugin to use this version of valkyrie, and also disable the async logging in there since its gonna make the order undeterministic