### PR TITLE
improve logging for gcp logs explorer

### DIFF
--- a/ops/logging_middleware.go
+++ b/ops/logging_middleware.go
@@ -49,9 +49,9 @@ func requestResponseLogging(c *fiber.Ctx) error {
 
 	if !bytes.HasSuffix(path, pathPing) {
 		if err != nil {
-			log.Ctx(c.UserContext()).Error().Func(LogHTTPResponse(c.Response(), err)).Msg("http server response")
+			log.Ctx(c.UserContext()).Error().Func(LogHTTPResponse(c.Request(), c.Response(), err)).Msg("http server response")
 		} else {
-			log.Ctx(c.UserContext()).Debug().Func(LogHTTPResponse(c.Response(), nil)).Msg("http server response")
+			log.Ctx(c.UserContext()).Debug().Func(LogHTTPResponse(c.Request(), c.Response(), nil)).Msg("http server response")
 		}
 	}
 

--- a/ops/logging_test.go
+++ b/ops/logging_test.go
@@ -97,6 +97,23 @@ func TestLogHTTPResponse(t *testing.T) {
 	assert.Contains(t, captor.String(), "\"response\":\"foo\"")
 }
 
+func TestLogHTTPResponseSkipEmptyContentType(t *testing.T) {
+	captor := strings.Builder{}
+	logger := zerolog.New(&captor)
+
+	response := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(response)
+	response.Header.SetContentType("")
+
+	request := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(request)
+	request.Header.SetContentType("")
+
+	logger.Debug().Func(LogHTTPResponse(request, response, nil)).Send()
+
+	assert.NotContains(t, captor.String(), "\"Content-Type\":\"\"")
+}
+
 func Test_isContentTypeJson(t *testing.T) {
 	assert.True(t, isContentTypeJSON([]byte(fiber.MIMEApplicationJSON)))
 	assert.True(t, isContentTypeJSON([]byte("application/vnd.kafka.v2+json")))

--- a/rest/client.go
+++ b/rest/client.go
@@ -233,9 +233,9 @@ func (c Client) postOrPut(
 
 	err := c.fastClient.DoTimeout(req, resp, c.config.RequestTimeout)
 	if err != nil {
-		log.Ctx(ctx).Error().Func(ops.LogHTTPResponse(resp, err)).Msg("http client response")
+		log.Ctx(ctx).Error().Func(ops.LogHTTPResponse(req, resp, err)).Msg("http client response")
 	} else {
-		log.Ctx(ctx).Debug().Func(ops.LogHTTPResponse(resp, err)).Msg("http client response")
+		log.Ctx(ctx).Debug().Func(ops.LogHTTPResponse(req, resp, err)).Msg("http client response")
 	}
 	ops.TraceHTTPAttributes(span, req, resp, err)
 
@@ -290,9 +290,9 @@ func (c Client) get(
 
 	err := c.fastClient.DoTimeout(req, resp, c.config.RequestTimeout)
 	if err != nil {
-		log.Ctx(ctx).Error().Func(ops.LogHTTPResponse(resp, err)).Msg("http client response")
+		log.Ctx(ctx).Error().Func(ops.LogHTTPResponse(req, resp, err)).Msg("http client response")
 	} else {
-		log.Ctx(ctx).Debug().Func(ops.LogHTTPResponse(resp, err)).Msg("http client response")
+		log.Ctx(ctx).Debug().Func(ops.LogHTTPResponse(req, resp, err)).Msg("http client response")
 	}
 	ops.TraceHTTPAttributes(span, req, resp, err)
 


### PR DESCRIPTION
* To avoid breaking the highlighting provided from following Googles recommended log format: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
  * Made the "response"-logging at the end of a request contain the full info (requestBody, responseBody etc, compatible with gcp log format like before)
  * Made the "request"-logging just be a slim log marker with a few fields to identify the request (requestUrl, requestMethod). (not compatible with googles log format, so it won't. get the highlighting)
* Bit of refactoring due to functions growing too large
* Fixed an issue where empty content-type or content-encoding was being logged