### PR TITLE
adjust helm chart defaults

### DIFF
--- a/helm/templates/hpa.yaml
+++ b/helm/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "valkyrie.fullname" . }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -89,17 +89,13 @@ ingress:
         # serviceName: service-name
         # servicePort: port
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  requests:
+    cpu: 100m
+    memory: 48Mi
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
* checked apiVersion for all manifests
* added default resource requests for cpu/mem - from my experience you always want to set these in production type environments, otherwise Kubernetes might end up over provisioning nodes. I did however leave limits out since we don't really want to enforce any upper bound there I think.