### PR TITLE
New parsing option for timestamp header

### DIFF
--- a/provider/caleta/caletagaming-caleta-gaming_system_api_operators_guide-1.5-oapi3.yaml
+++ b/provider/caleta/caletagaming-caleta-gaming_system_api_operators_guide-1.5-oapi3.yaml
@@ -599,7 +599,6 @@ components:
       description: Event or transaction timestamp in UTC
       x-go-type: caletaDate
       type: string
-      format: date-time
       example: 2023-01-17 08:13:17.985795+00:00
     BalanceResponse:
       required:

--- a/provider/caleta/models.go
+++ b/provider/caleta/models.go
@@ -10,11 +10,21 @@ import (
 // unmarshaller.
 type caletaDate time.Time
 
-const format = "2006-01-02 15:04:05.999999-07:00"
+const TimestampFormat = "2006-01-02 15:04:05.999999-07:00"
+
+// UnmarshalText is actually preferred when parsing header params
+func (c *MsgTimestamp) UnmarshalText(text []byte) error {
+	tt, err := time.Parse(TimestampFormat, string(text))
+	if err != nil {
+		return err
+	}
+	*c = MsgTimestamp(tt)
+	return nil
+}
 
 func (c *MsgTimestamp) UnmarshalJSON(in []byte) error {
 	s := strings.Trim(string(in), "\"")
-	tt, err := time.Parse(format, s)
+	tt, err := time.Parse(TimestampFormat, s)
 	if err != nil {
 		return err
 	}

--- a/provider/caleta/models_test.go
+++ b/provider/caleta/models_test.go
@@ -10,12 +10,23 @@ import (
 	"github.com/valkyrie-fnd/valkyrie/provider/caleta"
 )
 
-var sampleTime = `"2023-01-17 08:13:17.985795+00:00"`
+var sampleTime = "2023-01-17 08:13:17.985795+00:00"
+var sampleTimeWithQuotes = `"2023-01-17 08:13:17.985795+00:00"`
 var sampleTimeInstance = time.UnixMicro(1673943197985795)
 
-func Test_unmarshallMsgTimestamp(t *testing.T) {
+func Test_unmarshallTextMsgTimestamp(t *testing.T) {
+	var x caleta.MsgTimestamp
+	err := x.UnmarshalText([]byte(sampleTime))
+	assert.NoError(t, err)
+	assert.True(t, sampleTimeInstance.Equal(time.Time(x)))
+
+	err = x.UnmarshalText([]byte("complete gibberish"))
+	assert.Error(t, err)
+}
+
+func Test_unmarshallJSONMsgTimestamp(t *testing.T) {
 	var params caleta.MsgTimestamp
-	err := json.Unmarshal([]byte(sampleTime), &params)
+	err := json.Unmarshal([]byte(sampleTimeWithQuotes), &params)
 	assert.NoError(t, err)
 	assert.True(t, sampleTimeInstance.Equal(time.Time(params)))
 }


### PR DESCRIPTION
Apparently generated code requires `encoding.TextUnmarshaler` for header parameters with custom unmarshalling. Otherwise some very odd logic tries to construct a JSON string before parsing.