### PR TITLE
Add support for running go vulncheck locally

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,6 +30,7 @@ tasks:
     desc: default task
     cmds: # run the tasks sequentially
       - task: tidy
+      - task: dependency:vulncheck
       - task: gen
       - task: lint
       - task: test
@@ -90,7 +91,7 @@ tasks:
       - go install gotest.tools/gotestsum@latest
       - gotestsum
 
-  coverage:
+  test:coverage:
     desc: run all tests with code coverage
     cmds:
       - go test -cover -covermode=count -coverprofile=profile.cov ./...
@@ -268,24 +269,24 @@ tasks:
       - echo 'documentation served from http://localhost:8080/'
       - godoc -http=localhost:8080
 
-  outdated:
+  dependency:outdated:
     desc: list directly dependent modules that can be upgraded
     cmds:
       - go list -u -m $(go list -m -f '{{`{{.Indirect}} {{.}}`}}' all | grep '^false' | cut -d ' ' -f2) | grep '\['
 
-  graph:
+  dependency:graph:
     desc: graph of upstream modules with gmchart
     cmds:
       - go install github.com/PaulXu-cn/go-mod-graph-chart/gmchart@latest
       - go mod graph | gmchart
 
-  licenses:
+  dependency:licenses:
     desc: list project dependency licenses
     cmds:
       - go install github.com/google/go-licenses@latest
       - go-licenses report .
 
-  binmap:
+  dependency:binmap:
     desc: treemap breakdown of binary
     deps:
       - build
@@ -294,7 +295,14 @@ tasks:
       - go tool nm -size ./build/valkyrie | go-binsize-treemap > ./build/binsize.svg
       - open ./build/binsize.svg
 
-  bench:
+  dependency:vulncheck:
+    desc: analyze dependencies for known vulnerabilities
+    sources:
+      - ./go.mod
+    cmds:
+      - go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  test:bench:
     desc: run benchmarks
     cmds:
       - go test -bench=. -benchmem ./...

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -286,7 +286,7 @@ tasks:
       - go install github.com/google/go-licenses@latest
       - go-licenses report .
 
-  dependency:binmap:
+  binmap:
     desc: treemap breakdown of binary
     deps:
       - build

--- a/go.mod
+++ b/go.mod
@@ -37,24 +37,16 @@ require (
 )
 
 require (
-	cloud.google.com/go/compute/metadata v0.2.3 // indirect
-	github.com/deepmap/oapi-codegen v1.12.4 // indirect
-	github.com/fatih/color v1.13.0 // indirect
-	github.com/hashicorp/yamux v0.1.1 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
-	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
-	github.com/oklog/run v1.1.0 // indirect
-	go.opentelemetry.io/otel/metric v0.34.0 // indirect
-)
-
-require (
 	cloud.google.com/go/compute v1.15.1 // indirect
+	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/trace v1.5.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.34.2 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/deepmap/oapi-codegen v1.12.4 // indirect
+	github.com/fatih/color v1.13.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
@@ -69,12 +61,16 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.2.1 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/hashicorp/go-plugin v1.4.8
+	github.com/hashicorp/yamux v0.1.1 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.15.14 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/oklog/run v1.1.0 // indirect
 	github.com/openzipkin/zipkin-go v0.4.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
@@ -83,6 +79,7 @@ require (
 	github.com/valyala/tcplisten v1.0.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib v1.12.0 // indirect
+	go.opentelemetry.io/otel/metric v0.34.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/crypto v0.5.0 // indirect


### PR DESCRIPTION
From my understanding GitHub Dependabot & govulncheck uses https://pkg.go.dev/vuln/, which uses https://nvd.nist.gov/, which is a good baseline. Other tools also use https://nvd.nist.gov/, but might add their own vulnerabilities on top (sonatype nancy was not totally clear). 

Had a look at report from dependency-check too which reported a few warnings, but some of these were false alerts (tool mixed together other repos with different owners). Given that its Go scanner is still experimental I think we should let it be for now.

So my suggestion is to continue using Dependabot as primary tool, but I added govulncheck to our build tooling to allow us to get earlier feedback during development (as they use same vuln databases).

* organized tasks related to dependency category
* formatted go.mod