### PR TITLE
Cleanup wrong user response

### DIFF
--- a/pam/error.go
+++ b/pam/error.go
@@ -87,7 +87,7 @@ var pamToValkError = map[ErrorCode]ValkErrorCode{
 	PAMERRGAMENOTFOUND:          ValkErrOpGameNotFound,
 	PAMERRMISSINGPROVIDER:       ValkErrOpMissingProvider,
 	PAMERRNEGATIVESTAKE:         ValkErrOpNegativeStake,
-	PAMERRPLAYERNOTFOUND:        ValkErrOpUserNotFound,
+	PAMERRPLAYERNOTFOUND:        ValkErrOpSessionNotFound,
 	PAMERRSESSIONEXPIRED:        ValkErrOpSessionExpired,
 	PAMERRSESSIONNOTFOUND:       ValkErrOpSessionNotFound,
 	PAMERRTRANSALREADYCANCELLED: ValkErrOpCancelExists,

--- a/provider/caleta/test/caleta_integration_test.go
+++ b/provider/caleta/test/caleta_integration_test.go
@@ -59,40 +59,6 @@ func (s *CaletaIntegrationTestSuite) SetupTest() {
 	s.Require().NoError(s.client.SetupSession(currency))
 }
 
-/*
- * C's manual tests are:
- *
- * Test Open Game - Open all games and validate icons, game ids and different languages - not applicable
- * Test Open Demo Game - Open all games and confirm the DEMO version is working fine. - not applicable
- * Test Place Bet - Place bets on different currencies and games. Confirm balance and debit values are ok and check the back office. - check
- * Test Receive Winnings - Test different winnings from different games and situations: Bonus, Free Spins, Extra Balls - check
- * Test Rollback - Forcing a bet to fail by changing the Wallet URL - the system will force a rollback. Caleta RGS only rollback bets, winnings are never rolled back. - check
- * Test Retry - Forcing a Rollback or Win to fail by changing the Wallet URL - the system will try to retry the transaction until succeeding - not applicable
- * Test Bingos: Extra Balls - Play Bingos and test Extra Ball game - the operator must support additional bets inside the same round; rollbacks on extra balls don't invalidate the round, only the failed transaction. - check
- * Acceptance Tests on Client - Exploratory tests on some selected games to confirm game flow is ok. In this phase, we also perform Postman calls, simulating bad-intended users to confirm round will be invalidated. - not applicable
- *
- */
-
-/*
-Errors to test:
-	RSERRORBETLIMITEXCEEDED        Status = "RS_ERROR_BET_LIMIT_EXCEEDED" TODO: not implemented in genericpam (yet)
-	RSERRORDUPLICATETRANSACTION    Status = "RS_ERROR_DUPLICATE_TRANSACTION" - check
-	RSERRORINVALIDGAME             Status = "RS_ERROR_INVALID_GAME" - check
-	RSERRORINVALIDSIGNATURE        Status = "RS_ERROR_INVALID_SIGNATURE" - check
-	RSERRORINVALIDTOKEN            Status = "RS_ERROR_INVALID_TOKEN" - check
-	RSERRORNOTENOUGHMONEY          Status = "RS_ERROR_NOT_ENOUGH_MONEY" - check
-	RSERRORTIMEOUT                 Status = "RS_ERROR_TIMEOUT" TODO: a bit tricky to test
-	RSERRORTOKENEXPIRED            Status = "RS_ERROR_TOKEN_EXPIRED" - check
-	RSERRORTRANSACTIONDOESNOTEXIST Status = "RS_ERROR_TRANSACTION_DOES_NOT_EXIST" - check
-	RSERRORTRANSACTIONROLLEDBACK   Status = "RS_ERROR_TRANSACTION_ROLLED_BACK" - check
-	RSERRORUNKNOWN                 Status = "RS_ERROR_UNKNOWN" - TODO: maybe applicable once we have implementation
-	RSERRORUSERDISABLED            Status = "RS_ERROR_USER_DISABLED" - check
-	RSERRORWRONGCURRENCY           Status = "RS_ERROR_WRONG_CURRENCY" - check
-	RSERRORWRONGSYNTAX             Status = "RS_ERROR_WRONG_SYNTAX" - TODO: doesn't make sense to me, but maybe applicable once we have implementation
-	RSERRORWRONGTYPES              Status = "RS_ERROR_WRONG_TYPES" - TODO: doesn't make sense to me, but maybe applicable once we have implementation
-	RSOK                           Status = "RS_OK" - check
-*/
-
 func (s *CaletaIntegrationTestSuite) Test_Check() {
 	check, err := s.client.Check()
 	s.Assert().NoError(err)

--- a/provider/evolution/errors.go
+++ b/provider/evolution/errors.go
@@ -48,7 +48,7 @@ var errCodes = map[pam.ValkErrorCode]statusCode{
 	pam.ValkErrOpSessionNotFound: StatusInvalidSID,
 	pam.ValkErrOpCashOverdraft:   StatusInsufficientFunds,
 	pam.ValkErrAuth:              StatusInvalidTokenID,
-	pam.ValkErrOpUserNotFound:    StatusInvalidParameter,
+	pam.ValkErrOpUserNotFound:    StatusInvalidSID,
 	pam.ValkErrAlreadySettled:    StatusBetAlreadySettled,
 	pam.ValkErrBetNotFound:       StatusBetDoesNotExist,
 	pam.ValkErrOpCancelNotFound:  StatusBetDoesNotExist,

--- a/provider/evolution/test/evo_integration_test.go
+++ b/provider/evolution/test/evo_integration_test.go
@@ -377,10 +377,10 @@ func (s *EvolutionIntegrationTestSuite) Test_checkUsingInvalidUserId() {
 	client, initialBalance := s.prepareCase(validUser)
 
 	// Put in requests userId = 'fakeUserId'. Initialize (method check() call).
-	//		Verify response - response must contain status INVALID_PARAMETER.
+	//		Verify response - response must contain status INVALID_SID.
 	_ = client.checkWithAssert(client.reqBase.SID, fakeUser, func(cur *evolution.CheckResponse, err error) {
 		s.Require().NoError(err)
-		s.Assert().Equal("INVALID_PARAMETER", cur.Status, "Check on invalid user id should fail")
+		s.Assert().Equal("INVALID_SID", cur.Status, "Check on invalid user id should fail")
 	})
 
 	// Put in requests correct userId value.  Initialize (method check() call).
@@ -396,10 +396,10 @@ func (s *EvolutionIntegrationTestSuite) Test_checkUsingInvalidUserId() {
 	client.balanceWithAnyAssert(s.statusCodeAssert("OK", "Valid user gets balance"))
 
 	// Put in requests userId = 'fakeUserId'. Place bet.
-	//		Verify response - response must contain status INVALID_PARAMETER. Verify balance.
+	//		Verify response - response must contain status INVALID_SID. Verify balance.
 	client.reqBase.UserID = fakeUser
 	gameRoundID, refID := rnd(), rnd()
-	client.placeBet(10, tableIDTestValue, "", gameRoundID, refID, s.statusCodeAssert("INVALID_PARAMETER"))
+	client.placeBet(10, tableIDTestValue, "", gameRoundID, refID, s.statusCodeAssert("INVALID_SID"))
 
 	// Check balance. Verify response - response must contain status OK. Verify balance.
 	client.reqBase.UserID = validUser
@@ -411,18 +411,18 @@ func (s *EvolutionIntegrationTestSuite) Test_checkUsingInvalidUserId() {
 	transID1 := client.placeBet(10, tableIDTestValue, "", gameRoundID, refID, balanceStatusAssert(s.T(), initialBalance.Balance, -10))
 
 	// Put in requests userId = 'fakeUserId'. Cancel Bet.
-	//		Verify response - response must contain status INVALID_PARAMETER. Verify balance.
+	//		Verify response - response must contain status INVALID_SID. Verify balance.
 	client.reqBase.UserID = fakeUser
-	client.cancelBet(10, tableIDTestValue, gameRoundID, transID1, refID, s.statusCodeAssert("INVALID_PARAMETER"))
+	client.cancelBet(10, tableIDTestValue, gameRoundID, transID1, refID, s.statusCodeAssert("INVALID_SID"))
 
 	// Check balance. Verify response - response must contain status OK. Verify balance.
 	client.reqBase.UserID = validUser
 	client.balanceWithAssert(s.T(), initialBalance.Balance, -10, "Fake user transactions should not affect balance")
 
 	// Put in requests userId = 'fakeUserId'. Credit Bet.
-	//		Verify response - response must contain status INVALID_PARAMETER. Verify balance.
+	//		Verify response - response must contain status INVALID_SID. Verify balance.
 	client.reqBase.UserID = fakeUser
-	client.settleBet(2, tableIDTestValue, gameRoundID, refID, s.statusCodeAssert("INVALID_PARAMETER"))
+	client.settleBet(2, tableIDTestValue, gameRoundID, refID, s.statusCodeAssert("INVALID_SID"))
 
 	// Check balance. Verify response - response must contain status OK. Verify balance.
 	client.reqBase.UserID = validUser

--- a/provider/redtiger/errors.go
+++ b/provider/redtiger/errors.go
@@ -44,7 +44,7 @@ var errCodes = map[pam.ValkErrorCode]RTErrorCode{
 	pam.ValkErrRefundPromoValue:    InternalServerError,
 	pam.ValkErrCancel:              InternalServerError,
 	pam.ValkErrOpTransCurrency:     InvalidUserCurrency,
-	pam.ValkErrOpUserNotFound:      UserNotFound,
+	pam.ValkErrOpUserNotFound:      NotAuthorized,
 	pam.ValkErrOpAccountNotFound:   UserNotFound,
 	pam.ValkErrOpBonusOverdraft:    InsufficientFunds,
 	pam.ValkErrOpCashOverdraft:     InsufficientFunds,
@@ -65,6 +65,11 @@ func getError(valkError pam.ValkErrorCode) RTErrorCode {
 }
 
 func newRTErrorResponse(msg string, code RTErrorCode) ErrorResponse {
+	// In case of auth errors limit details
+	if code == NotAuthorized {
+		msg = "Not authorized"
+	}
+
 	return ErrorResponse{
 		Success: false,
 		Error: Error{

--- a/provider/redtiger/router_test.go
+++ b/provider/redtiger/router_test.go
@@ -222,7 +222,7 @@ func TestDeclineTokenMiddleware(t *testing.T) {
 			"application/json",
 			"recon",
 			401,
-			`{"success":false,"error":{"message":"API authentication error","code":301}}`,
+			`{"success":false,"error":{"message":"Not authorized","code":301}}`,
 		},
 	}
 	router, _ := NewProviderRouter(configs.ProviderConf{

--- a/provider/redtiger/test/integration_test.go
+++ b/provider/redtiger/test/integration_test.go
@@ -107,7 +107,7 @@ func (s *RedTigerIntegrationTestSuite) Test_MAKES_A_BET_WITH_AN_INVALID_USER_ID(
 	resp, err := s.client.Stake(gameID, rnd(), rnd(), toMoney(10.0), toMoney(0.0))
 	s.Require().Error(err, "Request should produce hard error")
 	s.Assert().False(resp.Success)
-	s.Assert().Equal(redtiger.UserNotFound, resp.Error.Code)
+	s.Assert().Equal(redtiger.NotAuthorized, resp.Error.Code)
 }
 
 func (s *RedTigerIntegrationTestSuite) Test_MAKES_A_BET_REQUEST_WITH_AN_INVALID_CURRENCY() {
@@ -231,7 +231,7 @@ func (s *RedTigerIntegrationTestSuite) Test_MAKES_AN_AWARD_REQUEST_WITH_INVALID_
 	resp, err := s.client.Payout(gameID, rnd(), rnd(), toMoney(10.0), toMoney(0.0), toMoney(0.0), toJackpotMoney(0.0))
 	s.Require().Error(err, "Request should produce hard error")
 	s.Assert().False(resp.Success)
-	s.Assert().Equal(redtiger.UserNotFound, resp.Error.Code)
+	s.Assert().Equal(redtiger.NotAuthorized, resp.Error.Code)
 }
 
 func (s *RedTigerIntegrationTestSuite) Test_MAKES_AN_AWARD_REQUEST_WITH_RECON_TOKEN_AND_INVALID_USER_ID() {
@@ -240,7 +240,7 @@ func (s *RedTigerIntegrationTestSuite) Test_MAKES_AN_AWARD_REQUEST_WITH_RECON_TO
 	resp, err := s.client.Payout(gameID, rnd(), rnd(), toMoney(10.0), toMoney(0.0), toMoney(0.0), toJackpotMoney(0.0))
 	s.Require().Error(err, "Request should produce hard error")
 	s.Assert().False(resp.Success)
-	s.Assert().Equal(redtiger.UserNotFound, resp.Error.Code)
+	s.Assert().Equal(redtiger.NotAuthorized, resp.Error.Code)
 }
 
 func (s *RedTigerIntegrationTestSuite) Test_MAKES_AN_AWARD_REQUEST_WITH_INVALID_CURRENCY() {


### PR DESCRIPTION
In order to remove a possible for IDOR-ish flaw the error responses for unknown and mismatching user id will always be a generic session error