### PR TITLE
add initial delay for liveness and readiness probes

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -57,10 +57,12 @@ spec:
               containerPort: 8083
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: 10
             httpGet:
               path: /monitoring/ping
               port: http-operator
           readinessProbe:
+            initialDelaySeconds: 10
             httpGet:
               path: /monitoring/ping
               port: http-operator


### PR DESCRIPTION
* default initial delay is 0s, which can cause unnecessary alerts that are fixed once application has finished starting