### PR TITLE
Return error when getRoundTransactions fails

### DIFF
--- a/provider/caleta/error.go
+++ b/provider/caleta/error.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/valkyrie-fnd/valkyrie/pam"
+	"github.com/valkyrie-fnd/valkyrie/rest"
 )
 
 func getCErrorStatus(err error) Status {
@@ -13,6 +14,11 @@ func getCErrorStatus(err error) Status {
 			return status
 		}
 	}
+
+	if errors.Is(err, rest.TimeoutError) {
+		return RSERRORTIMEOUT
+	}
+
 	return RSERRORUNKNOWN
 }
 
@@ -37,6 +43,5 @@ var errCodes = map[pam.ValkErrorCode]Status{
 
 // errors left:
 // RSERRORBETLIMITEXCEEDED
-// RSERRORTIMEOUT
 // RSERRORWRONGSYNTAX
 // RSERRORWRONGTYPES

--- a/provider/caleta/error_test.go
+++ b/provider/caleta/error_test.go
@@ -1,0 +1,49 @@
+package caleta
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/valkyrie-fnd/valkyrie/pam"
+	"github.com/valkyrie-fnd/valkyrie/rest"
+)
+
+func Test_getCErrorStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want Status
+	}{
+		{
+			"generic error",
+			errors.New("boom"),
+			RSERRORUNKNOWN,
+		},
+		{
+			"valkyrie timeout error",
+			pam.ValkyrieError{
+				ValkErrorCode: pam.ValkErrTimeout,
+			},
+			RSERRORTIMEOUT,
+		},
+		{
+			"valkyrie session expired error",
+			pam.ValkyrieError{
+				ValkErrorCode: pam.ValkErrOpSessionExpired,
+			},
+			RSERRORTOKENEXPIRED,
+		},
+		{
+			"http timeout error",
+			rest.TimeoutError,
+			RSERRORTIMEOUT,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, getCErrorStatus(tt.err), "getCErrorStatus(%v)", tt.err)
+		})
+	}
+}


### PR DESCRIPTION
* this error will propagate back to Caleta, causing retries which is preferable to incorrect settlements when missing bet information