### PR TITLE
76 valkyrie has duplicate ping endpoints

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -59,12 +59,12 @@ spec:
           livenessProbe:
             initialDelaySeconds: 10
             httpGet:
-              path: /monitoring/ping
+              path: /ping
               port: http-operator
           readinessProbe:
             initialDelaySeconds: 10
             httpGet:
-              path: /monitoring/ping
+              path: /ping
               port: http-operator
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "valkyrie.fullname" . }}-operator:{{ .Values.operatorService.port }}/monitoring/ping']
+      args: ['{{ include "valkyrie.fullname" . }}-operator:{{ .Values.operatorService.port }}/ping']
   restartPolicy: Never

--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -51,7 +51,7 @@ func Stack(errs []error, target error) error {
 		return target
 	}
 
-	return Stack(errs[1:], fmt.Errorf("%s %w", target, errs[0]))
+	return Stack(errs[1:], fmt.Errorf("%s %w", target, errs[0])) //nolint
 }
 
 func EnvOrDefault(environmentKey, defaultValue string) string {

--- a/routes/monitoring_routes.go
+++ b/routes/monitoring_routes.go
@@ -8,14 +8,13 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/pprof"
 )
 
+var pingHandler = func(_ *fiber.Ctx) error { return nil }
+
 // MonitoringRoutes func for mounting monitoring routes.
 func MonitoringRoutes(a *fiber.App) {
 
 	// Create routes group.
 	route := a.Group("/monitoring")
-
-	// Ping for liveness checks
-	route.Get("/ping", func(_ *fiber.Ctx) error { return nil })
 
 	// Monitoring
 	route.Get("/metrics", monitor.New(monitor.Config{Title: "Valkyrie Metrics"}))

--- a/routes/monitoring_routes_test.go
+++ b/routes/monitoring_routes_test.go
@@ -13,9 +13,14 @@ func TestMonitoringRoutes(t *testing.T) {
 	app := fiber.New()
 	MonitoringRoutes(app)
 
-	assert.Equal(t, 4, int(app.HandlersCount()))
+	assert.Equal(t, 2, int(app.HandlersCount()))
+}
 
-	req := httptest.NewRequest(fiber.MethodGet, "/monitoring/ping", nil)
+func TestPing(t *testing.T) {
+	app := fiber.New()
+	app.Get("/ping", pingHandler)
+
+	req := httptest.NewRequest(fiber.MethodGet, "/ping", nil)
 	resp, err := app.Test(req)
 
 	assert.NoError(t, err, "ping route should work")

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -22,7 +22,7 @@ import (
 // ProviderRoutes Init the provider routes
 func ProviderRoutes(a *fiber.App, config *configs.ValkyrieConfig, pam pam.PamClient, httpClient rest.HTTPClientJSONInterface) error {
 	// ping endpoint is public and used by load balancers for health checking
-	a.Get("/ping", func(_ *fiber.Ctx) error { return nil })
+	a.Get("/ping", pingHandler)
 
 	// Create providers subgroup and registry
 	registry := provider.NewRegistry(a, config.ProviderBasePath)
@@ -50,7 +50,7 @@ func ProviderRoutes(a *fiber.App, config *configs.ValkyrieConfig, pam pam.PamCli
 // OperatorRoutes Init the operator side routes
 func OperatorRoutes(a *fiber.App, config *configs.ValkyrieConfig, httpClient rest.HTTPClientJSONInterface) error {
 	// ping endpoint is public and used by load balancers for health checking
-	a.Get("/ping", func(_ *fiber.Ctx) error { return nil })
+	a.Get("/ping", pingHandler)
 
 	// Add authorization for operator paths
 	a.Use(config.OperatorBasePath, provider.OperatorAuthorization(config.OperatorAPIKey))

--- a/server/server.go
+++ b/server/server.go
@@ -176,7 +176,6 @@ func (v *Valkyrie) Run(ready func()) {
 	case <-v.ctx.Done():
 	case e := <-errs:
 		log.Error().Err(e).Msg("listener failed")
-		// FIXME: child contexts(like dwh_writer) will not always be given enough time to shutdown
 		v.cancel()
 	}
 


### PR DESCRIPTION
Opted for just `/ping` since it was already used in our load balancers. Also the /monitoring group was only available on one of the ports (8084), and it didn't make sense to add it for both ports 🤷 