### PR TITLE
Convert provider names to lcase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.8.1
 	github.com/swaggo/swag v1.8.10
-	github.com/valkyrie-fnd/valkyrie-stubs v0.0.0-20230209130924-d94d53318e43
+	github.com/valkyrie-fnd/valkyrie-stubs v0.0.0-20230220131541-7329394fb318
 	github.com/valyala/fasthttp v1.44.0
 	go.opentelemetry.io/otel v1.13.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/swaggo/files v1.0.0/go.mod h1:N59U6URJLyU1PQgFqPM7wXLMhJx7QAolnvfQkqO
 github.com/tinylib/msgp v1.1.6/go.mod h1:75BAfg2hauQhs3qedfdDZmWAPcFMAvJE5b9rGOMufyw=
 github.com/tinylib/msgp v1.1.8 h1:FCXC1xanKO4I8plpHGH2P7koL/RzZs12l/+r7vakfm0=
 github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=
-github.com/valkyrie-fnd/valkyrie-stubs v0.0.0-20230209130924-d94d53318e43 h1:f/8MmVpblabfNlqsRalwq+5+oy9sL8siEnX4tTRsjqM=
-github.com/valkyrie-fnd/valkyrie-stubs v0.0.0-20230209130924-d94d53318e43/go.mod h1:46Z0Eg/K0ixqGCCinzsW6nr0wr/QXmjsVJoYcPKKmUU=
+github.com/valkyrie-fnd/valkyrie-stubs v0.0.0-20230220131541-7329394fb318 h1:wB8Xjc2NUb54itlbFMJIinh6HiTVMCrCdDqS0x8ctxI=
+github.com/valkyrie-fnd/valkyrie-stubs v0.0.0-20230220131541-7329394fb318/go.mod h1:46Z0Eg/K0ixqGCCinzsW6nr0wr/QXmjsVJoYcPKKmUU=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.44.0 h1:R+gLUhldIsfg1HokMuQjdQ5bh9nuXHPIfvkYUu9eR5Q=

--- a/provider/caleta/model_mapper_test.go
+++ b/provider/caleta/model_mapper_test.go
@@ -53,12 +53,12 @@ func Test_betTransactionMapper(t *testing.T) {
 			want: &pam.AddTransactionRequest{
 				Params: pam.AddTransactionParams{
 					XPlayerToken: "tkn",
-					Provider:     "Caleta",
+					Provider:     "caleta",
 				},
 				Body: pam.Transaction{
 					TransactionDateTime:   now,
 					TransactionType:       pam.WITHDRAW,
-					Provider:              "Caleta",
+					Provider:              "caleta",
 					CashAmount:            toPamAmount(1),
 					Currency:              "EUR",
 					ProviderTransactionId: "id",
@@ -86,12 +86,12 @@ func Test_betTransactionMapper(t *testing.T) {
 			want: &pam.AddTransactionRequest{
 				Params: pam.AddTransactionParams{
 					XPlayerToken: "tkn",
-					Provider:     "Caleta",
+					Provider:     "caleta",
 				},
 				Body: pam.Transaction{
 					TransactionDateTime:   time.Now(),
 					TransactionType:       pam.WITHDRAW,
-					Provider:              "Caleta",
+					Provider:              "caleta",
 					CashAmount:            toPamAmount(1),
 					Currency:              "EUR",
 					ProviderTransactionId: "id",
@@ -145,12 +145,12 @@ func Test_promoBetTransactionMapper(t *testing.T) {
 			want: &pam.AddTransactionRequest{
 				Params: pam.AddTransactionParams{
 					XPlayerToken: "tkn",
-					Provider:     "Caleta",
+					Provider:     "caleta",
 				},
 				Body: pam.Transaction{
 					TransactionDateTime:   now,
 					TransactionType:       pam.PROMOWITHDRAW,
-					Provider:              "Caleta",
+					Provider:              "caleta",
 					PromoAmount:           toPamAmount(1),
 					Currency:              "EUR",
 					ProviderTransactionId: "id",
@@ -178,12 +178,12 @@ func Test_promoBetTransactionMapper(t *testing.T) {
 			want: &pam.AddTransactionRequest{
 				Params: pam.AddTransactionParams{
 					XPlayerToken: "tkn",
-					Provider:     "Caleta",
+					Provider:     "caleta",
 				},
 				Body: pam.Transaction{
 					TransactionDateTime:   time.Now(),
 					TransactionType:       pam.PROMOWITHDRAW,
-					Provider:              "Caleta",
+					Provider:              "caleta",
 					PromoAmount:           toPamAmount(1),
 					Currency:              "EUR",
 					ProviderTransactionId: "id",
@@ -239,12 +239,12 @@ func Test_winTransactionMapper(t *testing.T) {
 			want: &pam.AddTransactionRequest{
 				Params: pam.AddTransactionParams{
 					XPlayerToken: "tkn",
-					Provider:     "Caleta",
+					Provider:     "caleta",
 				},
 				Body: pam.Transaction{
 					TransactionDateTime:   now,
 					TransactionType:       pam.DEPOSIT,
-					Provider:              "Caleta",
+					Provider:              "caleta",
 					CashAmount:            toPamAmount(1),
 					Currency:              "EUR",
 					ProviderTransactionId: "id",
@@ -273,12 +273,12 @@ func Test_winTransactionMapper(t *testing.T) {
 			want: &pam.AddTransactionRequest{
 				Params: pam.AddTransactionParams{
 					XPlayerToken: "tkn",
-					Provider:     "Caleta",
+					Provider:     "caleta",
 				},
 				Body: pam.Transaction{
 					TransactionDateTime:   time.Now(),
 					TransactionType:       pam.DEPOSIT,
-					Provider:              "Caleta",
+					Provider:              "caleta",
 					CashAmount:            toPamAmount(1),
 					Currency:              "EUR",
 					ProviderTransactionId: "id",
@@ -334,12 +334,12 @@ func Test_promoWinTransactionMapper(t *testing.T) {
 			want: &pam.AddTransactionRequest{
 				Params: pam.AddTransactionParams{
 					XPlayerToken: "tkn",
-					Provider:     "Caleta",
+					Provider:     "caleta",
 				},
 				Body: pam.Transaction{
 					TransactionDateTime:   now,
 					TransactionType:       pam.PROMODEPOSIT,
-					Provider:              "Caleta",
+					Provider:              "caleta",
 					PromoAmount:           toPamAmount(1),
 					Currency:              "EUR",
 					ProviderTransactionId: "id",
@@ -368,12 +368,12 @@ func Test_promoWinTransactionMapper(t *testing.T) {
 			want: &pam.AddTransactionRequest{
 				Params: pam.AddTransactionParams{
 					XPlayerToken: "tkn",
-					Provider:     "Caleta",
+					Provider:     "caleta",
 				},
 				Body: pam.Transaction{
 					TransactionDateTime:   time.Now(),
 					TransactionType:       pam.PROMODEPOSIT,
-					Provider:              "Caleta",
+					Provider:              "caleta",
 					PromoAmount:           toPamAmount(1),
 					Currency:              "EUR",
 					ProviderTransactionId: "id",
@@ -429,12 +429,12 @@ func Test_cancelTransactionMapper(t *testing.T) {
 			want: &pam.AddTransactionRequest{
 				Params: pam.AddTransactionParams{
 					XPlayerToken: "tkn",
-					Provider:     "Caleta",
+					Provider:     "caleta",
 				},
 				Body: pam.Transaction{
 					TransactionDateTime:   now,
 					TransactionType:       pam.PROMOCANCEL,
-					Provider:              "Caleta",
+					Provider:              "caleta",
 					Currency:              "EUR",
 					ProviderTransactionId: "id",
 					ProviderBetRef:        utils.Ptr("ref"),
@@ -460,12 +460,12 @@ func Test_cancelTransactionMapper(t *testing.T) {
 			want: &pam.AddTransactionRequest{
 				Params: pam.AddTransactionParams{
 					XPlayerToken: "tkn",
-					Provider:     "Caleta",
+					Provider:     "caleta",
 				},
 				Body: pam.Transaction{
 					TransactionDateTime:   time.Now(),
 					TransactionType:       pam.PROMOCANCEL,
-					Provider:              "Caleta",
+					Provider:              "caleta",
 					Currency:              "EUR",
 					ProviderTransactionId: "id",
 					ProviderBetRef:        utils.Ptr("ref"),

--- a/provider/caleta/router.go
+++ b/provider/caleta/router.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	ProviderName = "Caleta"
+	ProviderName = "caleta"
 )
 
 func init() {

--- a/provider/caleta/test/testdata/datastore.config.yaml
+++ b/provider/caleta/test/testdata/datastore.config.yaml
@@ -4,7 +4,7 @@
 pamApiToken: pam-api-token
 
 providers:
-  - provider: Caleta
+  - provider: caleta
     providerId: 5
 
 games:

--- a/provider/evolution/router.go
+++ b/provider/evolution/router.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ProviderName      = "Evolution"
+	ProviderName      = "evolution"
 	apiTokenParamName = "authToken"
 )
 

--- a/provider/evolution/test/testdata/datastore.config.yaml
+++ b/provider/evolution/test/testdata/datastore.config.yaml
@@ -5,7 +5,7 @@ pamApiToken: pam-api-token
 
 providers:
   - &provider
-    provider: Evolution
+    provider: evolution
     providerId: 3
 
 providerApiKeys:

--- a/provider/redtiger/router.go
+++ b/provider/redtiger/router.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	ProviderName = "Red Tiger"
+	ProviderName = "redtiger"
 )
 
 func init() {

--- a/provider/redtiger/test/testdata/datastore.config.yaml
+++ b/provider/redtiger/test/testdata/datastore.config.yaml
@@ -5,7 +5,7 @@ pamApiToken: pam-api-token
 
 providers:
   - &provider
-    provider: Red Tiger
+    provider: redtiger
     providerId: 4
 
 providerApiKeys:

--- a/routes/provider_routes_test.go
+++ b/routes/provider_routes_test.go
@@ -65,7 +65,7 @@ func Test_OperatorRoutes(t *testing.T) {
 		{
 			name: "Evolution",
 			conf: configs.ProviderConf{
-				Name: "Evolution",
+				Name: "evolution",
 				Auth: map[string]any{
 					"api_key":      "",
 					"casino_token": "",
@@ -78,7 +78,7 @@ func Test_OperatorRoutes(t *testing.T) {
 		{
 			name: "Red Tiger",
 			conf: configs.ProviderConf{
-				Name: "Red Tiger",
+				Name: "redtiger",
 				Auth: map[string]any{
 					"api_key":     "",
 					"recon_token": "",

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 
@@ -29,6 +30,7 @@ func ProviderRoutes(a *fiber.App, config *configs.ValkyrieConfig, pam pam.PamCli
 
 	// Register all configured providers
 	for _, c := range config.Providers {
+		c.Name = lCaseNoWhitespace(c.Name)
 		providerRouter, err := provider.ProviderFactory().
 			Build(c.Name, provider.ProviderArgs{
 				Config:     c,
@@ -75,4 +77,8 @@ func OperatorRoutes(a *fiber.App, config *configs.ValkyrieConfig, httpClient res
 	}
 
 	return nil
+}
+
+func lCaseNoWhitespace(str string) string {
+	return strings.ReplaceAll(strings.ToLower(str), " ", "")
 }

--- a/routes/routes_test.go
+++ b/routes/routes_test.go
@@ -1,0 +1,38 @@
+package routes
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valkyrie-fnd/valkyrie/pam"
+	"github.com/valkyrie-fnd/valkyrie/provider"
+)
+
+// Verify that all providers are registered, which is easily forgotten
+// since it's done implicitly in the init() function of the provider package.
+func Test_AllProvidersGetsRegistered(t *testing.T) {
+
+	fs, err := os.ReadDir("../provider")
+	require.NoError(t, err)
+
+	for _, f := range fs {
+		if f.IsDir() && f.Name() != "internal" && f.Name() != "docs" {
+
+			r, err := provider.ProviderFactory().Build(f.Name(), provider.ProviderArgs{
+				PamClient: &dummyPamClient{},
+			})
+			require.NoError(t, err)
+			assert.NotNil(t, r)
+		}
+	}
+}
+
+type dummyPamClient struct {
+	pam.PamClient
+}
+
+func (d dummyPamClient) GetTransactionSupplier() pam.TransactionSupplier {
+	return pam.OPERATOR
+}


### PR DESCRIPTION
In order to verify that all providers are registered and to use provider names from config for actual logic they need to match routes and package names, instead of being pretty. 

Values read from config are converted to not break already deployed configs

As a bonus a test is added which verifies that all provider implementations are actually registered. 