### PR TITLE
Add casinoId to gamerender request

### DIFF
--- a/example/example-game-provider/provider_service.go
+++ b/example/example-game-provider/provider_service.go
@@ -30,6 +30,6 @@ func (s *exampleProviderService) GameLaunch(c *fiber.Ctx, r *provider.GameLaunch
 
 // GetGameRoundRender implements provider.ProviderService
 // It should return a url where the specific round is rendered
-func (s *exampleProviderService) GetGameRoundRender(c *fiber.Ctx, gameRoundID string) (string, error) {
-	return fmt.Sprintf("%s/gameround/render?roundId=%s", s.conf.URL, gameRoundID), nil
+func (s *exampleProviderService) GetGameRoundRender(c *fiber.Ctx, renderReq provider.GameRoundRenderRequest) (string, error) {
+	return fmt.Sprintf("%s/gameround/render?roundId=%s", s.conf.URL, renderReq.GameRoundID), nil
 }

--- a/provider/caleta/api_client.go
+++ b/provider/caleta/api_client.go
@@ -15,7 +15,7 @@ import (
 
 type API interface {
 	requestGameLaunch(ctx context.Context, body GameUrlBody) (*InlineResponse200, error)
-	getGameRoundRender(ctx context.Context, gameRoundID string) (*gameRoundRenderResponse, error)
+	getGameRoundRender(ctx context.Context, gameRoundID, casinoID string) (*gameRoundRenderResponse, error)
 	getRoundTransactions(ctx context.Context, gameRoundID string) (*transactionResponse, error)
 }
 
@@ -112,10 +112,13 @@ func (apiClient *apiClient) requestGameLaunch(ctx context.Context, body GameUrlB
 	return &resp, err
 }
 
-func (apiClient *apiClient) getGameRoundRender(ctx context.Context, gameRoundID string) (*gameRoundRenderResponse, error) {
+func (apiClient *apiClient) getGameRoundRender(ctx context.Context, gameRoundID, casinoID string) (*gameRoundRenderResponse, error) {
 	body := GameroundJSONRequestBody{
 		Round:      &gameRoundID,
 		OperatorId: apiClient.operatorID,
+	}
+	if casinoID != "" {
+		body.SubPartnerId = &casinoID
 	}
 	req := &rest.HTTPRequest{
 		URL:     fmt.Sprintf("%s%s", apiClient.url, "/api/game/round"),
@@ -131,7 +134,6 @@ func (apiClient *apiClient) getGameRoundRender(ctx context.Context, gameRoundID 
 	resp := gameRoundRenderResponse{}
 	err = apiClient.rest.PostJSON(ctx, req, &resp)
 	return &resp, err
-
 }
 
 func (apiClient *apiClient) getRoundTransactions(ctx context.Context, gameRoundID string) (*transactionResponse, error) {

--- a/provider/caleta/api_client_test.go
+++ b/provider/caleta/api_client_test.go
@@ -220,7 +220,7 @@ func Test_getGameRoundRender(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			api, err := NewAPIClient(mockRestClient{JSONFunc: test.jsonFn}, test.config)
 			assert.NoError(t, err)
-			result, err := api.getGameRoundRender(context.TODO(), test.gameRoundID)
+			result, err := api.getGameRoundRender(context.TODO(), test.gameRoundID, "")
 			if test.e != nil {
 				assert.EqualError(t, err, test.e.Error())
 			}

--- a/provider/caleta/caletagaming-caleta-gaming_system_api_operators_guide-1.5-oapi3.yaml
+++ b/provider/caleta/caletagaming-caleta-gaming_system_api_operators_guide-1.5-oapi3.yaml
@@ -1498,6 +1498,8 @@ components:
           $ref: '#/components/schemas/user'
         round:
           $ref: '#/components/schemas/round'
+        sub_partner_id:
+          $ref: '#/components/schemas/sub_partner_id'
     wallet_check_body:
       required:
       - token

--- a/provider/caleta/models.gen.go
+++ b/provider/caleta/models.gen.go
@@ -584,6 +584,9 @@ type GameRoundBody struct {
 	// Round Game round id. Used to relate all bets and wins in one round. All transactions related to the same round will have the same value in this field. It's unique through whole system.
 	Round *Round `json:"round,omitempty"`
 
+	// SubPartnerId Id of Operator's sub-partner (brand, whitelabel, site, etc.) which uses same integration and credentials as Operator.
+	SubPartnerId *SubPartnerId `json:"sub_partner_id,omitempty"`
+
 	// TransactionUuid Unique wallet transaction.
 	TransactionUuid *TransactionUuid `json:"transaction_uuid,omitempty"`
 

--- a/provider/caleta/provider_service.go
+++ b/provider/caleta/provider_service.go
@@ -33,8 +33,8 @@ func NewCaletaService(apiClient API, config configs.ProviderConf) (*caletaServic
 }
 
 // GetGameRoundRender returns a game render for a given game round
-func (service *caletaService) GetGameRoundRender(ctx *fiber.Ctx, gameRoundID string) (string, error) {
-	resp, err := service.apiClient.getGameRoundRender(ctx.UserContext(), gameRoundID)
+func (service *caletaService) GetGameRoundRender(ctx *fiber.Ctx, gameRoundRenderReq provider.GameRoundRenderRequest) (string, error) {
+	resp, err := service.apiClient.getGameRoundRender(ctx.UserContext(), gameRoundRenderReq.GameRoundID, gameRoundRenderReq.CasinoID)
 	if err != nil {
 		return "", err
 	}

--- a/provider/caleta/provider_service_test.go
+++ b/provider/caleta/provider_service_test.go
@@ -56,7 +56,7 @@ func (api *mockAPIClient) requestGameLaunch(ctx context.Context, body GameUrlBod
 	return api.requestGameLaunchFn(ctx, body)
 }
 
-func (api *mockAPIClient) getGameRoundRender(ctx context.Context, gameRoundID string) (*gameRoundRenderResponse, error) {
+func (api *mockAPIClient) getGameRoundRender(ctx context.Context, gameRoundID, casinoID string) (*gameRoundRenderResponse, error) {
 	return api.getGameRoundRenderFn(ctx, gameRoundID)
 }
 
@@ -264,7 +264,7 @@ func Test_Requesting_Gameround_Render_Page(t *testing.T) {
 	assert.NoError(t, err)
 	app := fiber.New()
 	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
-	res, _ := service.GetGameRoundRender(ctx, "gameRoundId")
+	res, _ := service.GetGameRoundRender(ctx, provider.GameRoundRenderRequest{GameRoundID: "gameRoundId"})
 	assert.Equal(t, "successUrl", res)
 }
 
@@ -275,7 +275,7 @@ func Test_Requesting_Gameround_Render_Page_error_missing_url(t *testing.T) {
 	assert.NoError(t, err)
 	app := fiber.New()
 	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
-	res, err := service.GetGameRoundRender(ctx, "gameRoundId")
+	res, err := service.GetGameRoundRender(ctx, provider.GameRoundRenderRequest{GameRoundID: "gameRoundId"})
 	assert.Equal(t, "", res)
 	assert.EqualError(t, err, "HTTP 400: 0: ")
 }
@@ -287,7 +287,7 @@ func Test_Requesting_Gameround_Render_Page_error_from_response(t *testing.T) {
 	assert.NoError(t, err)
 	app := fiber.New()
 	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
-	res, err := service.GetGameRoundRender(ctx, "gameRoundId")
+	res, err := service.GetGameRoundRender(ctx, provider.GameRoundRenderRequest{GameRoundID: "gameRoundId"})
 	assert.Equal(t, "", res)
 	assert.EqualError(t, err, "HTTP 400: 100: Bad Stuff")
 }
@@ -299,7 +299,7 @@ func Test_Requesting_Gameround_Render_Page_error_posting(t *testing.T) {
 	assert.NoError(t, err)
 	app := fiber.New()
 	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
-	res, err := service.GetGameRoundRender(ctx, "gameRoundId")
+	res, err := service.GetGameRoundRender(ctx, provider.GameRoundRenderRequest{GameRoundID: "gameRoundId"})
 	assert.Equal(t, "", res)
 	assert.EqualError(t, err, "Some network error")
 }

--- a/provider/docs/operator_api.yml
+++ b/provider/docs/operator_api.yml
@@ -48,7 +48,7 @@ paths:
                 type: string
               example: Bad game launch call
         "401":
-          $ref: '#/components/responses/UnauthorizedResponse'
+          $ref: "#/components/responses/UnauthorizedResponse"
   /{provider}/gamerounds/{gameRoundId}/render:
     get:
       description: Optional. Returns a rendered representation of the specified game round.
@@ -69,11 +69,18 @@ paths:
           example: xyz123
           schema:
             type: string
+        - in: query
+          name: casinoId
+          description: casino id requesting to see the game round being rendered
+          example: xyz10101
+          required: false
+          schema:
+            type: string
       responses:
         "302":
           description: Redirect to provider specific url with rendered result
-        "401": 
-          $ref: '#/components/responses/UnauthorizedResponse'
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
         "500":
           description: Something went wrong fetching the rendered page
 components:
@@ -130,7 +137,7 @@ components:
       example: 7ca10daf12f2cac9fecf559b11f0f0c8bd21ae43
       minLength: 1
       maxLength: 40
-  responses: 
+  responses:
     UnauthorizedResponse:
       description: Operator API Key is missing or invalid
   securitySchemes:

--- a/provider/evolution/provider_service.go
+++ b/provider/evolution/provider_service.go
@@ -63,7 +63,7 @@ func (service EvoService) GameLaunch(ctx *fiber.Ctx, g *provider.GameLaunchReque
 	return gameURL, nil
 }
 
-func (service EvoService) GetGameRoundRender(*fiber.Ctx, string) (string, error) {
+func (service EvoService) GetGameRoundRender(*fiber.Ctx, provider.GameRoundRenderRequest) (string, error) {
 	return "", fmt.Errorf("Not available")
 }
 

--- a/provider/evolution/provider_service_test.go
+++ b/provider/evolution/provider_service_test.go
@@ -129,6 +129,6 @@ func TestGameLaunchService_GameLaunch(t *testing.T) {
 
 func TestGameRoundRender(t *testing.T) {
 	sut := EvoService{}
-	_, err := sut.GetGameRoundRender(nil, "")
+	_, err := sut.GetGameRoundRender(nil, provider.GameRoundRenderRequest{})
 	assert.EqualError(t, err, "Not available")
 }

--- a/provider/gamelaunch_controller_test.go
+++ b/provider/gamelaunch_controller_test.go
@@ -132,7 +132,7 @@ func (gs ProviderServiceMock) GameLaunch(_ *fiber.Ctx, gr *GameLaunchRequest, h 
 	}
 	return "", nil
 }
-func (gs ProviderServiceMock) GetGameRoundRender(*fiber.Ctx, string) (string, error) {
+func (gs ProviderServiceMock) GetGameRoundRender(*fiber.Ctx, GameRoundRenderRequest) (string, error) {
 	return "", fmt.Errorf("Not Available")
 }
 

--- a/provider/gameround_controller.go
+++ b/provider/gameround_controller.go
@@ -18,7 +18,8 @@ func NewGameRoundController(s ProviderService) *GameRoundController {
 // GetGameRoundEndpoint Returns redirect status with provider url for game round rendering
 func (ctrl *GameRoundController) GetGameRoundEndpoint(c *fiber.Ctx) error {
 	gameRoundID := c.Params("gameRoundId")
-	res, err := ctrl.ps.GetGameRoundRender(c, gameRoundID)
+	casinoID := c.Query("casinoId")
+	res, err := ctrl.ps.GetGameRoundRender(c, GameRoundRenderRequest{gameRoundID, casinoID})
 	if err != nil {
 		herr := &rest.HTTPError{}
 		if errors.As(err, herr) {

--- a/provider/gameround_controller_test.go
+++ b/provider/gameround_controller_test.go
@@ -21,14 +21,14 @@ type gameRenderWant struct {
 }
 type gameRenderTestData struct {
 	id              string
-	gameRoundRender func(id string) (string, error)
+	gameRoundRender func(req GameRoundRenderRequest) (string, error)
 	want            gameRenderWant
 }
 
 var gameRenderTests = []gameRenderTestData{
 	{
 		id: "abc123",
-		gameRoundRender: func(id string) (string, error) {
+		gameRoundRender: func(req GameRoundRenderRequest) (string, error) {
 			return "redirectUrl", nil
 		},
 		want: gameRenderWant{
@@ -41,7 +41,7 @@ var gameRenderTests = []gameRenderTestData{
 	},
 	{
 		id: "abc123",
-		gameRoundRender: func(id string) (string, error) {
+		gameRoundRender: func(req GameRoundRenderRequest) (string, error) {
 			return "", rest.HTTPError{Message: "Wrong Id Maybe", Code: 400}
 		},
 		want: gameRenderWant{
@@ -54,7 +54,7 @@ var gameRenderTests = []gameRenderTestData{
 	},
 	{
 		id: "abc123",
-		gameRoundRender: func(id string) (string, error) {
+		gameRoundRender: func(req GameRoundRenderRequest) (string, error) {
 			return "", fmt.Errorf("SomeOtherError")
 		},
 		want: gameRenderWant{
@@ -68,15 +68,15 @@ var gameRenderTests = []gameRenderTestData{
 }
 
 type gameRoundRenderService struct {
-	gameRoundRender func(id string) (string, error)
+	gameRoundRender func(req GameRoundRenderRequest) (string, error)
 }
 
 func (gs gameRoundRenderService) GameLaunch(_ *fiber.Ctx, gr *GameLaunchRequest, h *GameLaunchHeaders) (string, error) {
 	return "", fmt.Errorf("Not Available")
 }
-func (gs gameRoundRenderService) GetGameRoundRender(_ *fiber.Ctx, id string) (string, error) {
+func (gs gameRoundRenderService) GetGameRoundRender(_ *fiber.Ctx, req GameRoundRenderRequest) (string, error) {
 	if gs.gameRoundRender != nil {
-		return gs.gameRoundRender(id)
+		return gs.gameRoundRender(req)
 	}
 	return "", nil
 }

--- a/provider/model.go
+++ b/provider/model.go
@@ -35,10 +35,15 @@ type GameLaunchResponse struct {
 	GameURL string `json:"gameUrl"`
 }
 
+type GameRoundRenderRequest struct {
+	GameRoundID string
+	CasinoID    string
+}
+
 // ProviderService Contains Provider exposed features
 type ProviderService interface {
 	// GameLaunch returns url to game session
 	GameLaunch(*fiber.Ctx, *GameLaunchRequest, *GameLaunchHeaders) (string, error)
 	// GetGameRoundRender Returns url where a specific game round result is rendered to be viewed
-	GetGameRoundRender(*fiber.Ctx, string) (string, error)
+	GetGameRoundRender(*fiber.Ctx, GameRoundRenderRequest) (string, error)
 }

--- a/provider/redtiger/provider_service.go
+++ b/provider/redtiger/provider_service.go
@@ -50,7 +50,7 @@ func (service RedTigerService) GameLaunch(_ *fiber.Ctx, g *provider.GameLaunchRe
 		launchConfQuery.Encode())
 	return url, nil
 }
-func (service RedTigerService) GetGameRoundRender(*fiber.Ctx, string) (string, error) {
+func (service RedTigerService) GetGameRoundRender(*fiber.Ctx, provider.GameRoundRenderRequest) (string, error) {
 	return "", fmt.Errorf("Not available")
 }
 func getLaunchConfig(conf map[string]interface{}) (*rtGameLaunchConfig, error) {

--- a/provider/redtiger/provider_service_test.go
+++ b/provider/redtiger/provider_service_test.go
@@ -94,6 +94,6 @@ func TestGameLaunch(t *testing.T) {
 
 func TestGameRoundRender(t *testing.T) {
 	sut := RedTigerService{}
-	_, err := sut.GetGameRoundRender(nil, "")
+	_, err := sut.GetGameRoundRender(nil, provider.GameRoundRenderRequest{})
 	assert.EqualError(t, err, "Not available")
 }


### PR DESCRIPTION
- Gamerender request accept query parameter `?casinoId=xyz`
- Pass casinoId to caleta game render request as `sub_partner_id`